### PR TITLE
FIX: in_all_taxnomies

### DIFF
--- a/exopite-multifilter/public/class-exopite-multifilter-public.php
+++ b/exopite-multifilter/public/class-exopite-multifilter-public.php
@@ -624,7 +624,11 @@ class Exopite_Multifilter_Public {
          */
         if ( ! empty( $args['taxonomies_terms'] ) ) {
 
-            $args['query']['tax_query']['relation'] = ( $args['in_all_taxnomies'] ) ? 'AND' : 'OR';
+            if($args['in_all_taxnomies'] == "true"){
+                 $args['query']['tax_query']['relation'] = 'AND';
+            }else{
+                 $args['query']['tax_query']['relation'] = 'OR';
+            }
 
             foreach ( $args['taxonomies_terms'] as $taxonomy => $terms ) {
 


### PR DESCRIPTION
PHP v7:  string "true" || "false" in evaluation $args['query']['tax_query']['relation'] = ( $args['in_all_taxnomies'] ) ? 'AND' : 'OR';  is evaluated to TRUE everytime